### PR TITLE
feat: add `increment` and `decrement` functions to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # KinoProgressBar
 
-**TODO: Add description**
+KinoProgressBar is an Elixir library that provides interactive progress bars for Livebook using Kino. It allows you to easily create, update, and manage progress bars in your Livebook notebooks, enhancing the visual feedback for long-running processes or iterative tasks.
+
+## Features
+
+- Create customizable progress bars
+- Update progress bar values and maximums dynamically
+- Generate progress bars from enumerables
+- Seamless integration with Livebook and Kino
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `kino_progress_bar` to your list of dependencies in `mix.exs`:
+Add `kino_progress_bar` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -14,8 +20,29 @@ def deps do
   ]
 end
 ```
+## Usage
+Here are some basic usage examples:
+```elixir
+# Create a new progress bar
+progress_bar = KinoProgressBar.new(max: 100)
 
+# Update the progress bar
+KinoProgressBar.update(progress_bar, 50)
+
+# Create a progress bar from an enumerable
+1..100
+|> KinoProgressBar.from_enumerable(progress_bar)
+|> Enum.to_list()
+```
+For more detailed information and advanced usage, please refer to the HexDocs documentation.
+
+## Documentation
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at <https://hexdocs.pm/kino_progress_bar>.
 
+## Contributing
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `kino_progress_bar` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:kino_progress_bar, "~> 0.1.0"}
+    {:kino_progress_bar, "~> 0.2.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `kino_progress_bar` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:kino_progress_bar, "~> 0.2.1"}
+    {:kino_progress_bar, "~> 0.3.0"}
   ]
 end
 ```
@@ -28,6 +28,12 @@ progress_bar = KinoProgressBar.new(max: 100)
 
 # Update the progress bar
 KinoProgressBar.update(progress_bar, 50)
+
+# Increment the value by 1
+KinoProgressBar.increment(progress_bar)
+
+# Decrement the value by arbitrary amount
+KinoProgressBar.decrement(progress_bar, 5)
 
 # Create a progress bar from an enumerable
 1..100

--- a/lib/kino_progress_bar.ex
+++ b/lib/kino_progress_bar.ex
@@ -89,8 +89,93 @@ defmodule KinoProgressBar do
     Kino.JS.Live.cast(progress_bar, {:update, %{value: value}})
   end
 
+  @doc """
+  Updates the progress bar with a new value and a new maximum.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to update.
+    * `value` - The new value to set.
+    * `max` - The new maximum value.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.update(progress_bar, 75, 150)
+
+  """
   def update(progress_bar, value, max) do
     Kino.JS.Live.cast(progress_bar, {:update, %{value: value, max: max}})
+  end
+
+  @doc """
+  Increments the progress bar value by 1.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to increment.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.increment(progress_bar)
+
+  """
+  def increment(progress_bar) do
+    increment(progress_bar, 1)
+  end
+
+  @doc """
+  Increments the progress bar value by the specified step.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to increment.
+    * `step` - The value to increment by.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.increment(progress_bar, 5)
+
+  """
+  def increment(progress_bar, step) do
+    Kino.JS.Live.cast(progress_bar, {:increment, %{step: step}})
+  end
+
+  @doc """
+  Decrements the progress bar value by 1.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to decrement.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.decrement(progress_bar)
+
+  """
+  def decrement(progress_bar) do
+    decrement(progress_bar, 1)
+  end
+
+  @doc """
+  Decrements the progress bar value by the specified step.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to decrement.
+    * `step` - The value to decrement by.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.decrement(progress_bar, 5)
+
+  """
+  def decrement(progress_bar, step) do
+    Kino.JS.Live.cast(progress_bar, {:decrement, %{step: step}})
   end
 
   @impl true
@@ -121,6 +206,18 @@ defmodule KinoProgressBar do
   def handle_cast({:update, %{value: value, max: max} = updates}, ctx) do
     broadcast_event(ctx, "update", updates)
     {:noreply, assign(ctx, value: value, max: max)}
+  end
+
+  def handle_cast({:increment, %{step: step}}, ctx) do
+    value = ctx.assigns.value + step
+    broadcast_event(ctx, "update", %{value: value})
+    {:noreply, assign(ctx, value: value)}
+  end
+
+  def handle_cast({:decrement, %{step: step}}, ctx) do
+    value = ctx.assigns.value - step
+    broadcast_event(ctx, "update", %{value: value})
+    {:noreply, assign(ctx, value: value)}
   end
 
   @impl true

--- a/lib/kino_progress_bar.ex
+++ b/lib/kino_progress_bar.ex
@@ -85,7 +85,11 @@ defmodule KinoProgressBar do
       iex> KinoProgressBar.update(progress_bar, 75, 150)
 
   """
-  def update(progress_bar, value, max \\ nil) do
+  def update(progress_bar, value) do
+    Kino.JS.Live.cast(progress_bar, {:update, %{value: value}})
+  end
+
+  def update(progress_bar, value, max) do
     Kino.JS.Live.cast(progress_bar, {:update, %{value: value, max: max}})
   end
 
@@ -109,6 +113,11 @@ defmodule KinoProgressBar do
   end
 
   @impl true
+  def handle_cast({:update, %{value: value} = updates}, ctx) do
+    broadcast_event(ctx, "update", updates)
+    {:noreply, assign(ctx, value: value, max: ctx.assigns.max)}
+  end
+
   def handle_cast({:update, %{value: value, max: max} = updates}, ctx) do
     broadcast_event(ctx, "update", updates)
     {:noreply, assign(ctx, value: value, max: max)}
@@ -148,7 +157,6 @@ defmodule KinoProgressBar do
     """
     export function init(ctx, html) {
       ctx.root.innerHTML = html;
-
       ctx.handleEvent("update", ({max, value}) => {
         console.log(value);
         const [pb, counter_span, _] = document.getElementById("kino_pb").children;

--- a/lib/kino_progress_bar.ex
+++ b/lib/kino_progress_bar.ex
@@ -1,10 +1,31 @@
 defmodule KinoProgressBar do
+  @moduledoc """
+  A module for creating and managing progress bars in Livebook using Kino.
+
+  This module provides functionality to create interactive progress bars,
+  update their values, and handle progress for enumerables.
+  """
   use Kino.JS
   use Kino.JS.Live
 
   @ets :kino_progress_bar
   @update_interval 100
 
+  @doc """
+  Creates a new progress bar.
+
+  ## Options
+
+    * `:max` - The maximum value of the progress bar (required).
+    * `:value` - The initial value of the progress bar (default: 0).
+    * `:style` - CSS style to be applied to the progress bar (default: "height: 100%;").
+
+  ## Examples
+
+      iex> KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.new(max: 100, value: 50, style: "height: 20px; width: 100%;")
+
+  """
   def new(opts \\ []) do
     if :ets.whereis(@ets) == :undefined do
       @ets =
@@ -15,6 +36,21 @@ defmodule KinoProgressBar do
     Kino.JS.Live.new(__MODULE__, {opts[:value], opts[:max], opts[:style]})
   end
 
+  @doc """
+  Creates a progress bar from an enumerable, updating as the enumerable is processed.
+
+  ## Parameters
+
+    * `enumerable` - The enumerable to process.
+    * `progress_bar` - The progress bar created with `new/1`.
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.from_enumerable(1..100, progress_bar)
+      #Stream<...>
+
+  """
   def from_enumerable(enumerable, progress_bar) do
     save(progress_bar.pid, 0)
     send(progress_bar.pid, {:set_progress_bar, progress_bar})
@@ -33,6 +69,22 @@ defmodule KinoProgressBar do
     )
   end
 
+  @doc """
+  Updates the progress bar with a new value and optionally a new maximum.
+
+  ## Parameters
+
+    * `progress_bar` - The progress bar to update.
+    * `value` - The new value to set.
+    * `max` - The new maximum value (optional).
+
+  ## Examples
+
+      iex> progress_bar = KinoProgressBar.new(max: 100)
+      iex> KinoProgressBar.update(progress_bar, 50)
+      iex> KinoProgressBar.update(progress_bar, 75, 150)
+
+  """
   def update(progress_bar, value, max \\ nil) do
     Kino.JS.Live.cast(progress_bar, {:update, %{value: value, max: max}})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KinoProgressBar.MixProject do
   def project do
     [
       app: :kino_progress_bar,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KinoProgressBar.MixProject do
   def project do
     [
       app: :kino_progress_bar,
-      version: "0.2.1",
+      version: "0.3.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KinoProgressBar.MixProject do
   def project do
     [
       app: :kino_progress_bar,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
This PR introduces convenience methods allowing the bar's value to be increased or decreased without needing to keep track of the bar's value and update logic.